### PR TITLE
Remove deprecated ioutil

### DIFF
--- a/cmd/connectopus/connectopus.go
+++ b/cmd/connectopus/connectopus.go
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/exp/slices"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -155,7 +154,7 @@ var initCmd = &cobra.Command{
 				},
 			}
 		} else {
-			data, err := ioutil.ReadFile(configFilename)
+			data, err := os.ReadFile(configFilename)
 			if err != nil {
 				return fmt.Errorf("error reading config file: %w", err)
 			}
@@ -203,11 +202,11 @@ var initCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("error signing config data: %w", err)
 		}
-		err = ioutil.WriteFile(path.Join(dataDir, "config.yml"), newCfgData, 0600)
+		err = os.WriteFile(path.Join(dataDir, "config.yml"), newCfgData, 0600)
 		if err != nil {
 			return fmt.Errorf("error writing config file: %w", err)
 		}
-		err = ioutil.WriteFile(path.Join(dataDir, "config.sig"), sig, 0600)
+		err = os.WriteFile(path.Join(dataDir, "config.sig"), sig, 0600)
 		if err != nil {
 			return fmt.Errorf("error writing config signature: %w", err)
 		}
@@ -354,7 +353,7 @@ var getConfigCmd = &cobra.Command{
 		if configFilename == "" {
 			fmt.Printf(config.Config.Yaml)
 		} else {
-			err = ioutil.WriteFile(configFilename, []byte(config.Config.Yaml), 0600)
+			err = os.WriteFile(configFilename, []byte(config.Config.Yaml), 0600)
 			if err != nil {
 				return err
 			}
@@ -441,7 +440,7 @@ var editConfigCmd = &cobra.Command{
 			return fmt.Errorf("error getting current config: %w", err)
 		}
 		var tmpFile *os.File
-		tmpFile, err = ioutil.TempFile("", "connectopus-config-*.yml")
+		tmpFile, err = os.CreateTemp("", "connectopus-config-*.yml")
 		if err != nil {
 			return fmt.Errorf("error creating temp file: %w", err)
 		}
@@ -470,7 +469,7 @@ var editConfigCmd = &cobra.Command{
 			return fmt.Errorf("error running editor: %w", err)
 		}
 		var newYaml []byte
-		newYaml, err = ioutil.ReadFile(tmpFile.Name())
+		newYaml, err = os.ReadFile(tmpFile.Name())
 		if err != nil {
 			return fmt.Errorf("error reading temp file: %w", err)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,7 +5,6 @@ import (
 	"github.com/ghjm/connectopus/pkg/proto"
 	"gopkg.in/yaml.v3"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -92,8 +91,8 @@ func FindDataDirs(identity string) ([]string, error) {
 		}
 		return []string{dirName}, nil
 	}
-	var files []fs.FileInfo
-	files, err = ioutil.ReadDir(basePath)
+	var files []fs.DirEntry
+	files, err = os.ReadDir(basePath)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +114,7 @@ func (c *Config) Marshal() ([]byte, error) {
 }
 
 func (c *Config) Load(filename string) error {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
@@ -127,5 +126,5 @@ func (c *Config) Save(filename string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, data, 0600)
+	return os.WriteFile(filename, data, 0600)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"github.com/ghjm/connectopus/pkg/proto"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -73,7 +72,7 @@ var correctConfig = Config{
 }
 
 func TestConfig(t *testing.T) {
-	configFile, err := ioutil.TempFile("", "configtest")
+	configFile, err := os.CreateTemp("", "configtest")
 	if err != nil {
 		t.Fatalf("error creating tempfile: %s", err)
 	}

--- a/pkg/connectopus/connectopus.go
+++ b/pkg/connectopus/connectopus.go
@@ -20,8 +20,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/agent"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"os/exec"
 	"path"
 	"reflect"
@@ -89,13 +89,13 @@ func ParseAndCheckConfig(cfgData, signature []byte, authKeys []proto.Marshalable
 type Node reconciler.RunningItem
 
 func LoadConfig(datadir string) (*config.Config, error) {
-	data, err := ioutil.ReadFile(path.Join(datadir, "config.yml"))
+	data, err := os.ReadFile(path.Join(datadir, "config.yml"))
 	if err != nil {
 		return nil, fmt.Errorf("error loading config file: %w", err)
 	}
 
 	var sig []byte
-	sig, err = ioutil.ReadFile(path.Join(datadir, "config.sig"))
+	sig, err = os.ReadFile(path.Join(datadir, "config.sig"))
 	if err != nil {
 		return nil, fmt.Errorf("error reading signature file: %w", err)
 	}
@@ -166,11 +166,11 @@ func (ni *nodeInstance) NewConfig(config []byte, signature []byte) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(path.Join(ni.datadir, "config.yml"), config, 0600)
+	err = os.WriteFile(path.Join(ni.datadir, "config.yml"), config, 0600)
 	if err != nil {
 		return fmt.Errorf("error writing config.yml: %w", err)
 	}
-	err = ioutil.WriteFile(path.Join(ni.datadir, "config.sig"), signature, 0600)
+	err = os.WriteFile(path.Join(ni.datadir, "config.sig"), signature, 0600)
 	if err != nil {
 		return fmt.Errorf("error writing config.sig: %w", err)
 	}
@@ -236,12 +236,12 @@ func (nc NodeCfg) Start(ctx context.Context, ri *reconciler.RunningItem, done fu
 		ri:       ri,
 		datadir:  nc.datadir,
 	}
-	cfgData, err := ioutil.ReadFile(path.Join(nc.datadir, "config.yml"))
+	cfgData, err := os.ReadFile(path.Join(nc.datadir, "config.yml"))
 	if err != nil {
 		return nil, fmt.Errorf("error loading config.yml: %w", err)
 	}
 	var sigData []byte
-	sigData, err = ioutil.ReadFile(path.Join(nc.datadir, "config.sig"))
+	sigData, err = os.ReadFile(path.Join(nc.datadir, "config.sig"))
 	if err != nil {
 		return nil, fmt.Errorf("error loading config.sig: %w", err)
 	}

--- a/pkg/cpctl/cpctl_test.go
+++ b/pkg/cpctl/cpctl_test.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/goleak"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -22,7 +21,7 @@ import (
 
 func TestCpctl(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-	f, err := ioutil.TempFile("", "temp_cpctl_*.sock")
+	f, err := os.CreateTemp("", "temp_cpctl_*.sock")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/links/netns/netns_linux.go
+++ b/pkg/links/netns/netns_linux.go
@@ -16,7 +16,6 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -293,7 +292,7 @@ func RunShim(fd int, tunif string, mtu uint16, addr string, domain string, dnsSe
 
 	// Create resolv.conf
 	var rf *os.File
-	rf, err = ioutil.TempFile("", "connectopus-resolv-*.conf")
+	rf, err = os.CreateTemp("", "connectopus-resolv-*.conf")
 	if err != nil {
 		return fmt.Errorf("error creating resolv.conf temp file: %w", err)
 	}
@@ -317,12 +316,12 @@ func RunShim(fd int, tunif string, mtu uint16, addr string, domain string, dnsSe
 
 	// Create nsswitch.conf
 	var origNsf []byte
-	origNsf, err = ioutil.ReadFile("/etc/nsswitch.conf")
+	origNsf, err = os.ReadFile("/etc/nsswitch.conf")
 	if err != nil {
 		return fmt.Errorf("error reading nsswitch.conf: %w", err)
 	}
 	var nsf *os.File
-	nsf, err = ioutil.TempFile("", "connectopus-nsswitch-*.conf")
+	nsf, err = os.CreateTemp("", "connectopus-nsswitch-*.conf")
 	if err != nil {
 		return fmt.Errorf("error creating nsswitch.conf temp file: %w", err)
 	}

--- a/pkg/netstack/netstack_test.go
+++ b/pkg/netstack/netstack_test.go
@@ -10,7 +10,6 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
 	"io"
-	"io/ioutil"
 	"net"
 	"testing"
 	"time"
@@ -201,7 +200,7 @@ func testNetstack(t *testing.T, stackBuilder NewStackFunc) {
 	if err != nil {
 		t.Fatalf("dial TCP error: %s", err)
 	}
-	b, err := ioutil.ReadAll(c)
+	b, err := io.ReadAll(c)
 	if err != nil {
 		t.Fatalf("read TCP error: %s", err)
 	}

--- a/pkg/x/file_cleaner/file_cleaner_test.go
+++ b/pkg/x/file_cleaner/file_cleaner_test.go
@@ -1,13 +1,12 @@
 package file_cleaner
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestFileCleaner(t *testing.T) {
-	temp1, err := ioutil.TempFile("", "file_cleaner_test")
+	temp1, err := os.CreateTemp("", "file_cleaner_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -17,7 +16,7 @@ func TestFileCleaner(t *testing.T) {
 	}
 	DeleteOnExit(temp1.Name())
 	var temp2 *os.File
-	temp2, err = ioutil.TempFile("", "file_cleaner_test")
+	temp2, err = os.CreateTemp("", "file_cleaner_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/x/ssh_jwt/ssh_agent.go
+++ b/pkg/x/ssh_jwt/ssh_agent.go
@@ -7,7 +7,6 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"runtime"
@@ -20,7 +19,7 @@ type SSHAgent struct {
 }
 
 func getSSHAgentFromFile(keyFile string) (*SSHAgent, error) {
-	keyPEM, err := ioutil.ReadFile(keyFile)
+	keyPEM, err := os.ReadFile(keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("error reading key file: %w", err)
 	}


### PR DESCRIPTION
Replace calls to deprecated `ioutil` module with equivalent calls to `io` or `os`